### PR TITLE
disabled debug path display on 64px_NavigationAgent2D #75

### DIFF
--- a/assets/tilesets/kenney_scribbledungeons/kenney_scribbledungeons.tres
+++ b/assets/tilesets/kenney_scribbledungeons/kenney_scribbledungeons.tres
@@ -1,6 +1,6 @@
 [gd_resource type="TileSet" load_steps=35 format=3 uid="uid://yyt201a3jcf2"]
 
-[ext_resource type="Texture2D" uid="uid://ci2hnkv2hjirt" path="res://assets/tilesets/kenney_scribbledungeons/kenney_scribbledungeons_tilesheet_128px.png" id="1_rvqmi"]
+[ext_resource type="Texture2D" path="res://assets/tilesets/kenney_scribbledungeons/kenney_scribbledungeons_tilesheet_128px.png" id="1_rvqmi"]
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_xrj4n"]
 vertices = PackedVector2Array(-25.7143, -60, 25.7143, -60, 60, -25.7143, 60, 25.7143, 25.7143, 60, -25.7143, 60, -60, 25.7143, -60, -25.7143)

--- a/entities/shared/nav_mesh_2d_seeker.tscn
+++ b/entities/shared/nav_mesh_2d_seeker.tscn
@@ -3,8 +3,8 @@
 [ext_resource type="Script" path="res://entities/shared/NavMesh2DSeeker.cs" id="1_okc87"]
 [ext_resource type="Script" path="res://entities/shared/NavigateTowards2dNodes.cs" id="1_v72mj"]
 [ext_resource type="Texture2D" uid="uid://wjwfy0e7jfxb" path="res://icon.svg" id="1_wiouv"]
-[ext_resource type="PackedScene" uid="uid://dryxji2dl6v3p" path="res://entities/64_px_navigation_agent_2d.tscn" id="2_rcndb"]
-[ext_resource type="Texture2D" uid="uid://ctc4l4hk6ujq8" path="res://assets/neutral_point_light.webp" id="4_jv2rv"]
+[ext_resource type="PackedScene" path="res://entities/64_px_navigation_agent_2d.tscn" id="2_rcndb"]
+[ext_resource type="Texture2D" path="res://assets/neutral_point_light.webp" id="4_jv2rv"]
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_72851"]
 animations = [{
@@ -29,6 +29,7 @@ Targets = []
 
 [node name="64px_NavigationAgent2D" parent="." instance=ExtResource("2_rcndb")]
 avoidance_enabled = false
+debug_enabled = false
 
 [node name="NavigateTowards2dNodes" type="Node" parent="." node_paths=PackedStringArray("Parent", "Targets")]
 script = ExtResource("1_v72mj")


### PR DESCRIPTION
- disabled debug path display on 64px_NavigationAgent2D, Fixes #75
  - use `Debug > Visible Paths` instead